### PR TITLE
feat: base de datos agregue parametro fecha_alta_paciente

### DIFF
--- a/prisma/migrations/20251005205009_add_parametro_alta_pacientes/migration.sql
+++ b/prisma/migrations/20251005205009_add_parametro_alta_pacientes/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "public"."pacientes" ADD COLUMN     "fecha_alta_paciente" DATE NOT NULL DEFAULT CURRENT_TIMESTAMP;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -59,6 +59,7 @@ model pacientes {
   dni_paciente              String              @db.VarChar(8)
   telefono_paciente         String              @db.VarChar(20)
   fecha_nacimiento_paciente DateTime            @db.Date
+  fecha_alta_paciente       DateTime            @default(now()) @db.Date
   direccion_paciente        String?             @db.VarChar
   obra_social_id            Int
   obras_sociales            obras_sociales      @relation(fields: [obra_social_id], references: [id_obra_social], onDelete: NoAction, onUpdate: NoAction)


### PR DESCRIPTION
agregue en la tabla pacientes la fecha de alta de los pacientes. 
para que podamos tener eso registrado correctamente, y generar reportes varios tambien con ello.
la fecha con la que se cargan es formato año , mes, dia (creo) pero solo permite guardar esos parametros, no guarda hs ni minutos ni segundos